### PR TITLE
Statuses.{created,updated}_at: optional

### DIFF
--- a/src/statuses/mod.rs
+++ b/src/statuses/mod.rs
@@ -65,8 +65,8 @@ impl<'a> Statuses<'a> {
 
 #[derive(Debug, Deserialize)]
 pub struct Status {
-    pub created_at: String,
-    pub updated_at: String,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
     pub state: State,
     pub target_url: Option<String>,
     pub description: String,


### PR DESCRIPTION
As requested. Tested with `cargo  test` on `ofborg`. No warranty :P