### PR TITLE
checks: increase id number space

### DIFF
--- a/src/checks/mod.rs
+++ b/src/checks/mod.rs
@@ -37,7 +37,7 @@ impl<'a> CheckRuns<'a> {
         )
     }
 
-    pub fn update(&self, check_run_id: &i32, check_run_options: &CheckRunUpdateOptions) -> Result<CheckRun> {
+    pub fn update(&self, check_run_id: &u64, check_run_options: &CheckRunUpdateOptions) -> Result<CheckRun> {
         let data = serde_json::to_string(&check_run_options)?;
         self.github.patch_media::<CheckRun>(
             &self.path(&format!("/{}", check_run_id)),
@@ -174,7 +174,7 @@ pub struct CheckRunUpdateOptions {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct CheckRun {
-    pub id: i32,
+    pub id: u64,
     pub name: String,
     pub head_sha: String,
     pub url: String,


### PR DESCRIPTION
Fixes an issue where checks could no longer be posted after exceeding
the i32 number space:

    Failed to send check update: Error(Codec(Error("invalid value: integer `4279780491`, expected i32"

---

I just don't understand why some PRs still get checks pushed, and others don't...