### PR TITLE
checks: increase CheckSuite id number space

### DIFF
--- a/src/checks/mod.rs
+++ b/src/checks/mod.rs
@@ -208,5 +208,5 @@ pub struct CheckRun {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct CheckSuite {
-    pub id: u32,
+    pub id: u64,
 }


### PR DESCRIPTION
Missed this one.

    Failed to send check update: Error(Codec(Error("invalid value: integer `4787048773`, expected u32"